### PR TITLE
Fix #6 Where Validator.isValidIPv4CidrNotation wrongly validates rang…

### DIFF
--- a/spec/ValidatorTest.ts
+++ b/spec/ValidatorTest.ts
@@ -28,6 +28,7 @@ describe('Validator: ', () => {
             expect(Validator.isValidIPv4CidrNotation("123.234.334.0/34")[1].some(errorMessage => {return errorMessage ===Validator.invalidPrefixValueMessage})).toBe(true);
 
             expect(Validator.isValidIPv4CidrNotation('1.1.1.x/28')[0]).toBe(false);
+            expect(Validator.isValidIPv4CidrNotation("123.234.334.0/3x")[0]).toBe(false);
         });
     });
 

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -220,8 +220,12 @@ export class Validator {
         let ip = cidrComponents[0];
         let range = cidrComponents[1];
 
+        if (isNaN(Number(range))) {
+            return [false, [Validator.invalidIPv4CidrNotationMessage]];
+        }
+
         let [validIpv4, invalidIpv4Message] = Validator.isValidIPv4String(ip);
-        let [validPrefix, invalidPrefixMessage] = Validator.isValidPrefixValue(parseInt(range), IPNumType.IPv4);
+        let [validPrefix, invalidPrefixMessage] = Validator.isValidPrefixValue(Number(range), IPNumType.IPv4);
 
         let isValid = validIpv4 && validPrefix;
         let invalidMessage = invalidIpv4Message.concat(invalidPrefixMessage);


### PR DESCRIPTION
…es where the prefix is not a number