### PR TITLE
Enable IPv4-mapped IPv6 parsing

### DIFF
--- a/spec/IPv6Test.ts
+++ b/spec/IPv6Test.ts
@@ -82,6 +82,11 @@ describe('IPv6: ', () => {
         expect(iPv61.toString()).toEqual('::ffff:4a7d:2b63');
     });
 
+    it('should instantiate IPv6 from IPv4-mapped string', () => {
+        let ip = new IPv6("::ffff:127.0.0.1");
+        expect(ip.toString()).toEqual('0:0:0:0:0:ffff:7f00:1');
+    });
+
     it('should instantiate by calling fromBinaryString', () => {
         let IPv6String = "3ffe:1900:4545:0003:0200:f8ff:fe21:67cf";
 

--- a/spec/IPv6UtilsTest.ts
+++ b/spec/IPv6UtilsTest.ts
@@ -37,6 +37,8 @@ describe('IPv6 Utils', () => {
 
         expect(IPv6Utils.expandIPv6Number("2001:0555:0001:0800:0:0:0:0/50")).toBe("2001:0555:0001:0800:0000:0000:0000:0000/50");
         expect(IPv6Utils.expandIPv6Number("2001:0555:0001:0800:0000:0000:0000:0000/50")).toBe("2001:0555:0001:0800:0000:0000:0000:0000/50");
+
+        expect(IPv6Utils.expandIPv6Number("::ffff:127.0.0.1")).toBe("0000:0000:0000:0000:0000:ffff:7f00:0001");
     });
 
     it('Should correctly collapse long ipv6 number', () => {

--- a/spec/ValidatorTest.ts
+++ b/spec/ValidatorTest.ts
@@ -29,6 +29,7 @@ describe('Validator: ', () => {
             expect(Validator.isValidIPv6String('123.234.10.10')[0]).toBe(false);
             expect(Validator.isValidIPv6String('::123::')[0]).toBe(false);
             expect(Validator.isValidIPv6String('12::123::')[0]).toBe(false);
+            expect(Validator.isValidIPv6String('::ffff:127.0.0.1')[0]).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
- support IPv4-mapped IPv6 addresses when expanding IPv6 strings
- test expansion of mapped IPv6s
- allow constructing IPv6 from IPv4-mapped strings
- verify Validator accepts IPv4-mapped IPv6 addresses

Fixes https://github.com/ip-num/ip-num/issues/92
