### PR TITLE
Fix Validator.isValidIPv6Mask error handling

### DIFF
--- a/spec/ValidatorTest.ts
+++ b/spec/ValidatorTest.ts
@@ -131,4 +131,11 @@ describe('Validator: ', () => {
         expect(Validator.isValidIPv6CidrRange("2001:8a2e:370Q:733464")[0]).toBe(false)
       });
     })
+
+    describe('isValidIPv6Mask', () => {
+      it('should return false for invalid IPv6 mask string without throwing', () => {
+        expect(() => { Validator.isValidIPv6Mask(""); }).not.toThrow()
+        expect(Validator.isValidIPv6Mask("")[0]).toBe(false)
+      })
+    })
 });

--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -238,9 +238,13 @@ export class Validator {
      * contains "valid" or an error message when value is invalid
      */
     static isValidIPv6Mask(ipv6MaskString: string) : [boolean, string[]] {
-        let ipv6InBinary = hexadectetNotationToBinaryString(ipv6MaskString);
-        let isValid = Validator.IPV6_CONTIGUOUS_MASK_BIT_PATTERN.test(ipv6InBinary);
-        return isValid ? [isValid, []]: [isValid, [Validator.invalidMaskMessage]];
+        try {
+            let ipv6InBinary = hexadectetNotationToBinaryString(ipv6MaskString);
+            let isValid = Validator.IPV6_CONTIGUOUS_MASK_BIT_PATTERN.test(ipv6InBinary);
+            return isValid ? [isValid, []]: [isValid, [Validator.invalidMaskMessage]];
+        } catch (error) {
+            return [false, [String(error)]];
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- wrap IPv6 mask validation in try/catch so invalid strings return `false`
- add regression test for invalid IPv6 mask

Fixes #84